### PR TITLE
Add --embed-external-images command line flag

### DIFF
--- a/GLTFSceneKit/GLTFSceneSource.swift
+++ b/GLTFSceneKit/GLTFSceneSource.swift
@@ -16,22 +16,22 @@ public class GLTFSceneSource : SCNSceneSource {
         super.init()
     }
     
-    public convenience init(path: String, options: [SCNSceneSource.LoadingOption : Any]? = nil, extensions: [String:Codable.Type]? = nil) throws {
+    public convenience init(path: String, options: [SCNSceneSource.LoadingOption : Any]? = nil, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true) throws {
         self.init()
         
-        let loader = try GLTFUnarchiver(path: path, extensions: extensions)
+        let loader = try GLTFUnarchiver(path: path, extensions: extensions, embedExternalImages: embedExternalImages)
         self.loader = loader
     }
     
     public override convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]? = nil) {
-        self.init(url: url, options: options, extensions: nil)
+        self.init(url: url, options: options, extensions: nil, embedExternalImages: true)
     }
     
-    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?) {
+    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, embedExternalImages: Bool = true) {
         self.init()
         
         do {
-            self.loader = try GLTFUnarchiver(url: url, extensions: extensions)
+            self.loader = try GLTFUnarchiver(url: url, extensions: extensions, embedExternalImages: embedExternalImages)
         } catch {
             print("\(error.localizedDescription)")
         }

--- a/gltf2scn/main.swift
+++ b/gltf2scn/main.swift
@@ -21,17 +21,18 @@ import SceneKit
 command(
     Option<String>("template", default: "", description: "Path to a .scn file into which the .glb will be inserted"),
     Option<String>("template-parent-node", default: "", description: "Name of node in the template .scn under which the contents of the .glb will be added"),
+    Flag("embed-external-images", default: true, description: "Whether or not external images should be embedded in the resulting .scn"),
     Argument<String>("path", description: "Path to input .glb"),
     Argument<String>("outputPath", description: ".scn output path")
-) { templatePath, templateParentNode, path, outputPath in
-    
+) { templatePath, templateParentNode, embedExternalImages, path, outputPath in
+    print("embedExternalImages", embedExternalImages)
 //    let exportDelegate = ExportDelegate()
     
     var scene: SCNScene
     var templateScene = SCNScene()
     var parentNode: SCNNode
     do {
-        let sceneSource = try GLTFSceneSource(path: path)
+        let sceneSource = try GLTFSceneSource(path: path, embedExternalImages: embedExternalImages)
         scene = try sceneSource.scene()
         
         if templatePath != "" {


### PR DESCRIPTION
This CLI flag, combined with modifications to GLTFSceneSource and GLTFUnarchiver, makes it possible to create a SceneKit file whose textures are all external files.

The default behavior is still to embed external images. If you'd like images that are _already_ external files referenced within the `.gltf` file to _remain_ external files (and not be embedded), pass the `--no-embed-external-images` flag on the command line.

**Note:** this does not affect embedded images (e.g. in a `.glb` file), so chances are you should use a `.gltf` (without embedded textures) as your input file.

Example command line usage:

```bash
gltf2scn input.gltf output.scn --no-embed-external-images
```