### PR TITLE
Add --extract-embedded-images flag

### DIFF
--- a/ByteString.swift
+++ b/ByteString.swift
@@ -1,0 +1,126 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+/// A `ByteString` represents a sequence of bytes.
+///
+/// This struct provides useful operations for working with buffers of
+/// bytes. Conceptually it is just a contiguous array of bytes (UInt8), but it
+/// contains methods and default behavor suitable for common operations done
+/// using bytes strings.
+///
+/// This struct *is not* intended to be used for significant mutation of byte
+/// strings, we wish to retain the flexibility to micro-optimize the memory
+/// allocation of the storage (for example, by inlining the storage for small
+/// strings or and by eliminating wasted space in growable arrays). For
+/// construction of byte arrays, clients should use the `OutputByteStream` class
+/// and then convert to a `ByteString` when complete.
+public struct ByteString: ExpressibleByArrayLiteral, Hashable {
+    /// The buffer contents.
+    fileprivate var _bytes: [UInt8]
+    
+    /// Create an empty byte string.
+    public init() {
+        _bytes = []
+    }
+    
+    /// Create a byte string from a byte array literal.
+    public init(arrayLiteral contents: UInt8...) {
+        _bytes = contents
+    }
+    
+    /// Create a byte string from an array of bytes.
+    public init(_ contents: [UInt8]) {
+        _bytes = contents
+    }
+    
+    /// Create a byte string from an byte buffer.
+    public init<S: Sequence> (_ contents: S) where S.Iterator.Element == UInt8 {
+        _bytes = [UInt8](contents)
+    }
+    
+    /// Create a byte string from the UTF8 encoding of a string.
+    public init(encodingAsUTF8 string: String) {
+        _bytes = [UInt8](string.utf8)
+    }
+    
+    /// Access the byte string contents as an array.
+    public var contents: [UInt8] {
+        return _bytes
+    }
+    
+    /// Return the byte string size.
+    public var count: Int {
+        return _bytes.count
+    }
+    
+    /// Return the string decoded as a UTF8 sequence, if possible.
+    public var asString: String? {
+        // FIXME: This is very inefficient, we need a way to pass a buffer. It
+        // is also wrong if the string contains embedded '\0' characters.
+        let tmp = _bytes + [UInt8(0)]
+        return tmp.withUnsafeBufferPointer { ptr in
+            return String(validatingUTF8: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
+        }
+    }
+    
+    /// Return the string decoded as a UTF8 sequence, substituting replacement
+    /// characters for ill-formed UTF8 sequences.
+    public var asReadableString: String {
+        // FIXME: This is very inefficient, we need a way to pass a buffer. It
+        // is also wrong if the string contains embedded '\0' characters.
+        let tmp = _bytes + [UInt8(0)]
+        return tmp.withUnsafeBufferPointer { ptr in
+            return String(cString: unsafeBitCast(ptr.baseAddress, to: UnsafePointer<CChar>.self))
+        }
+    }
+}
+
+/// Conform to CustomStringConvertible.
+extension ByteString: CustomStringConvertible {
+    public var description: String {
+        // For now, default to the "readable string" representation.
+        return "<ByteString:\"\(asReadableString)\">"
+    }
+}
+
+#if !swift(>=4.2)
+extension ByteString {
+public var hashValue: Int {
+var result = contents.count
+for byte in contents {
+result = result &* 31 &+ Int(byte)
+}
+return result
+}
+}
+#endif
+
+/// ByteStreamable conformance for a ByteString.
+//extension ByteString: ByteStreamable {
+//    public func write(to stream: OutputByteStream) {
+//        stream.write(_bytes)
+//    }
+//}
+
+/// StringLiteralConvertable conformance for a ByteString.
+extension ByteString: ExpressibleByStringLiteral {
+    public typealias UnicodeScalarLiteralType = StringLiteralType
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+    
+    public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+        _bytes = [UInt8](value.utf8)
+    }
+    public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+        _bytes = [UInt8](value.utf8)
+    }
+    public init(stringLiteral value: StringLiteralType) {
+        _bytes = [UInt8](value.utf8)
+    }
+}

--- a/GLTFSceneKit/GLTFFunctions.swift
+++ b/GLTFSceneKit/GLTFFunctions.swift
@@ -235,7 +235,7 @@ func saveImageDataToFile(from data: Data, path: URL?, name: String?, mimeType: S
         ext = ""
     }
     
-    let filename = "\(String(describing: basename))\(ext)"
+    let filename = "\(basename)\(ext)"
     print("Attempting to write file '\(filename)'...")
     
     let fileManager = FileManager()

--- a/GLTFSceneKit/GLTFSceneSource.swift
+++ b/GLTFSceneKit/GLTFSceneSource.swift
@@ -16,10 +16,10 @@ public class GLTFSceneSource : SCNSceneSource {
         super.init()
     }
     
-    public convenience init(path: String, options: [SCNSceneSource.LoadingOption : Any]? = nil, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false) throws {
+    public convenience init(path: String, options: [SCNSceneSource.LoadingOption : Any]? = nil, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false, outputDirectoryPath: String? = nil) throws {
         self.init()
         
-        let loader = try GLTFUnarchiver(path: path, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages)
+        let loader = try GLTFUnarchiver(path: path, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages, outputDirectoryPath: outputDirectoryPath)
         self.loader = loader
     }
     
@@ -27,11 +27,11 @@ public class GLTFSceneSource : SCNSceneSource {
         self.init(url: url, options: options, extensions: nil, embedExternalImages: true, extractEmbeddedImages: true)
     }
     
-    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false) {
+    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false, outputDirectoryPath: String? = nil) {
         self.init()
         
         do {
-            self.loader = try GLTFUnarchiver(url: url, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages)
+            self.loader = try GLTFUnarchiver(url: url, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages, outputDirectoryPath: outputDirectoryPath)
         } catch {
             print("\(error.localizedDescription)")
         }

--- a/GLTFSceneKit/GLTFSceneSource.swift
+++ b/GLTFSceneKit/GLTFSceneSource.swift
@@ -16,22 +16,22 @@ public class GLTFSceneSource : SCNSceneSource {
         super.init()
     }
     
-    public convenience init(path: String, options: [SCNSceneSource.LoadingOption : Any]? = nil, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true) throws {
+    public convenience init(path: String, options: [SCNSceneSource.LoadingOption : Any]? = nil, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false) throws {
         self.init()
         
-        let loader = try GLTFUnarchiver(path: path, extensions: extensions, embedExternalImages: embedExternalImages)
+        let loader = try GLTFUnarchiver(path: path, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages)
         self.loader = loader
     }
     
     public override convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]? = nil) {
-        self.init(url: url, options: options, extensions: nil, embedExternalImages: true)
+        self.init(url: url, options: options, extensions: nil, embedExternalImages: true, extractEmbeddedImages: true)
     }
     
-    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, embedExternalImages: Bool = true) {
+    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false) {
         self.init()
         
         do {
-            self.loader = try GLTFUnarchiver(url: url, extensions: extensions, embedExternalImages: embedExternalImages)
+            self.loader = try GLTFUnarchiver(url: url, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages)
         } catch {
             print("\(error.localizedDescription)")
         }

--- a/GLTFSceneKit/GLTFUnarchiver.swift
+++ b/GLTFSceneKit/GLTFUnarchiver.swift
@@ -17,6 +17,7 @@ let chunkTypeBIN = 0x004E4942 // "BIN"
 
 public class GLTFUnarchiver {
     private var directoryPath: URL? = nil
+    private var outputDirectoryPath: URL? = nil
     private var json: GLTFGlTF! = nil
     private var bin: Data?
     
@@ -45,7 +46,7 @@ public class GLTFUnarchiver {
         private var workingAnimationGroup: CAAnimationGroup! = nil
     #endif
     
-    convenience public init(path: String, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false) throws {
+    convenience public init(path: String, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false, outputDirectoryPath: String? = nil) throws {
         var url: URL?
         if let mainPath = Bundle.main.path(forResource: path, ofType: "") {
             url = URL(fileURLWithPath: mainPath)
@@ -55,18 +56,22 @@ public class GLTFUnarchiver {
         guard let _url = url else {
             throw URLError(.fileDoesNotExist)
         }
-        try self.init(url: _url, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages)
+        try self.init(url: _url, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages, outputDirectoryPath: outputDirectoryPath)
     }
     
-    convenience public init(url: URL, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false) throws {
+    convenience public init(url: URL, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false, outputDirectoryPath: String? = nil) throws {
         let data = try Data(contentsOf: url)
-        try self.init(data: data, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages)
+        try self.init(data: data, extensions: extensions, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages, outputDirectoryPath: outputDirectoryPath)
         self.directoryPath = url.deletingLastPathComponent()
     }
     
-    public init(data: Data, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false) throws {
+    public init(data: Data, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true, extractEmbeddedImages: Bool = false, outputDirectoryPath: String? = nil) throws {
         self.embedExternalImages = embedExternalImages
         self.extractEmbeddedImages = extractEmbeddedImages
+        
+        if let _outputDirectoryPath = outputDirectoryPath {
+            self.outputDirectoryPath = URL(fileURLWithPath: _outputDirectoryPath)
+        }
         
         print("GLTFUnarchiver: self.embedExternalImages = ", self.embedExternalImages)
         print("GLTFUnarchiver: self.extractEmbeddedImages = ", self.extractEmbeddedImages)
@@ -805,7 +810,7 @@ public class GLTFUnarchiver {
                 if (self.extractEmbeddedImages) {
                     // Write the base64-encoded data to a file instead
                     print("Attempting to save base64-encoded image to file...")
-                    image = try saveImageDataToFile(from: data, path: self.directoryPath, name: glImage.name, mimeType: glImage.mimeType)
+                    image = try saveImageDataToFile(from: data, path: self.outputDirectoryPath ?? self.directoryPath, name: glImage.name, mimeType: glImage.mimeType)
                 } else {
                     image = try loadImageData(from: data)
                 }
@@ -822,7 +827,7 @@ public class GLTFUnarchiver {
             
             if (self.extractEmbeddedImages) {
                 print("Attempting to save bufferView embedded image to file...")
-                image = try saveImageDataToFile(from: bufferView, path: self.directoryPath, name: glImage.name, mimeType: glImage.mimeType)
+                image = try saveImageDataToFile(from: bufferView, path: self.outputDirectoryPath ?? self.directoryPath, name: glImage.name, mimeType: glImage.mimeType)
             } else {
                 image = try loadImageData(from: bufferView)
             }

--- a/gltf2scn/SHA256.swift
+++ b/gltf2scn/SHA256.swift
@@ -1,0 +1,218 @@
+/*
+ This source file is part of the Swift.org open source project
+ 
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+ 
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+/// SHA-256 implementation from Secure Hash Algorithm 2 (SHA-2) set of
+/// cryptographic hash functions (FIPS PUB 180-2).
+public final class SHA256 {
+    
+    /// The length of the output digest (in bits).
+    let digestLength = 256
+    
+    /// The size of each blocks (in bits).
+    let blockBitSize = 512
+    
+    /// The initial hash value.
+    private static let initalHashValue: [UInt32] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+    ]
+    
+    /// The constants in the algorithm (K).
+    private static let konstants: [UInt32] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+    ]
+    
+    /// The hash that is being computed.
+    private var hash = SHA256.initalHashValue
+    
+    /// The input that was provided. It will be padded when computing the digest.
+    private var input: [UInt8]
+    
+    /// The result, once computed.
+    private var result: [UInt8]?
+    
+    public init(_ input: [UInt8]) {
+        self.input = input
+    }
+    
+    public init(_ bytes: ByteString) {
+        self.input = bytes.contents
+    }
+    
+    public init(_ string: String) {
+        self.input = [UInt8](string.utf8)
+    }
+    
+    /// Returns the digest as hexadecimal string.
+    public func digestString() -> String {
+        return digest().reduce("") {
+            var str = String($1, radix: 16)
+            // The above method does not do zero padding.
+            if str.count == 1 {
+                str = "0" + str
+            }
+            return $0 + str
+        }
+    }
+    
+    /// Returns the digest.
+    public func digest() -> [UInt8] {
+        
+        // If we already have the result, we're done.
+        if let result = self.result {
+            return result
+        }
+        
+        // Pad the input.
+        pad(&input)
+        
+        // Break the input into N 512-bit blocks.
+        let messageBlocks = input.blocks(size: blockBitSize / 8)
+        
+        // Process each block.
+        for block in messageBlocks {
+            process(block)
+        }
+        
+        // Finally, compute the result.
+        var result = [UInt8](repeating: 0, count: digestLength / 8)
+        for (idx, element) in hash.enumerated() {
+            let pos = idx * 4
+            result[pos + 0] = UInt8((element >> 24) & 0xff)
+            result[pos + 1] = UInt8((element >> 16) & 0xff)
+            result[pos + 2] = UInt8((element >> 8) & 0xff)
+            result[pos + 3] = UInt8(element & 0xff)
+        }
+        
+        self.result = result
+        return result
+    }
+    
+    /// Process and compute hash from a block.
+    private func process(_ block: ArraySlice<UInt8>) {
+        
+        // Compute message schedule.
+        var W = [UInt32](repeating: 0, count: SHA256.konstants.count)
+        for t in 0..<W.count {
+            switch t {
+            case 0...15:
+                let index = block.startIndex.advanced(by: t * 4)
+                // Put 4 bytes in each message.
+                W[t]  = UInt32(block[index + 0]) << 24
+                W[t] |= UInt32(block[index + 1]) << 16
+                W[t] |= UInt32(block[index + 2]) << 8
+                W[t] |= UInt32(block[index + 3])
+            default:
+                let σ1 = W[t-2].rotateRight(by: 17) ^ W[t-2].rotateRight(by: 19) ^ (W[t-2] >> 10)
+                let σ0 = W[t-15].rotateRight(by: 7) ^ W[t-15].rotateRight(by: 18) ^ (W[t-15] >> 3)
+                W[t] = σ1 &+ W[t-7] &+ σ0 &+ W[t-16]
+            }
+        }
+        
+        var a = hash[0]
+        var b = hash[1]
+        var c = hash[2]
+        var d = hash[3]
+        var e = hash[4]
+        var f = hash[5]
+        var g = hash[6]
+        var h = hash[7]
+        
+        // Run the main algorithm.
+        for t in 0..<SHA256.konstants.count {
+            let Σ1 = e.rotateRight(by: 6) ^ e.rotateRight(by: 11) ^ e.rotateRight(by: 25)
+            let ch = (e & f) ^ (~e & g)
+            let t1 = h &+ Σ1 &+ ch &+ SHA256.konstants[t] &+ W[t]
+            
+            let Σ0 = a.rotateRight(by: 2) ^ a.rotateRight(by: 13) ^ a.rotateRight(by: 22)
+            let maj = (a & b) ^ (a & c) ^ (b & c)
+            let t2 = Σ0 &+ maj
+            
+            h = g
+            g = f
+            f = e
+            e = d &+ t1
+            d = c
+            c = b
+            b = a
+            a = t1 &+ t2
+        }
+        
+        hash[0] = a &+ hash[0]
+        hash[1] = b &+ hash[1]
+        hash[2] = c &+ hash[2]
+        hash[3] = d &+ hash[3]
+        hash[4] = e &+ hash[4]
+        hash[5] = f &+ hash[5]
+        hash[6] = g &+ hash[6]
+        hash[7] = h &+ hash[7]
+    }
+    
+    /// Pad the given byte array to be a multiple of 512 bits.
+    private func pad(_ input: inout [UInt8]) {
+        // Find the bit count of input.
+        let inputBitLength = input.count * 8
+        
+        // Append the bit 1 at end of input.
+        input.append(0x80)
+        
+        // Find the number of bits we need to append.
+        //
+        // inputBitLength + 1 + bitsToAppend ≡ 448 mod 512
+        let mod = inputBitLength % 512
+        let bitsToAppend = mod < 448 ? 448 - 1 - mod : 512 + 448 - mod - 1
+        
+        // We already appended first 7 bits with 0x80 above.
+        input += [UInt8](repeating: 0, count: (bitsToAppend - 7) / 8)
+        
+        // We need to append 64 bits of input length.
+        for byte in UInt64(inputBitLength).toByteArray().lazy.reversed() {
+            input.append(byte)
+        }
+        assert((input.count * 8) % 512 == 0, "Expected padded length to be 512.")
+    }
+}
+
+// MARK:- Helpers
+
+private extension UInt64 {
+    /// Converts the 64 bit integer into an array of single byte integers.
+    func toByteArray() -> [UInt8] {
+        var value = self.littleEndian
+        return withUnsafeBytes(of: &value, Array.init)
+    }
+}
+
+private extension UInt32 {
+    /// Rotates self by given amount.
+    func rotateRight(by amount: UInt32) -> UInt32 {
+        return (self >> amount) | (self << (32 - amount))
+    }
+}
+
+private extension Array {
+    /// Breaks the array into the given size.
+    func blocks(size: Int) -> AnyIterator<ArraySlice<Element>> {
+        var currentIndex = startIndex
+        return AnyIterator {
+            if let nextIndex = self.index(currentIndex, offsetBy: size, limitedBy: self.endIndex) {
+                defer { currentIndex = nextIndex }
+                return self[currentIndex..<nextIndex]
+            }
+            return nil
+        }
+    }
+}

--- a/gltf2scn/main.swift
+++ b/gltf2scn/main.swift
@@ -22,17 +22,19 @@ command(
     Option<String>("template", default: "", description: "Path to a .scn file into which the .glb will be inserted"),
     Option<String>("template-parent-node", default: "", description: "Name of node in the template .scn under which the contents of the .glb will be added"),
     Flag("embed-external-images", default: true, description: "Whether or not external images should be embedded in the resulting .scn"),
+    Flag("extract-embedded-images", default: false, description: "Whether or not to extract embedded images and externally reference them in the resulting .scn"),
     Argument<String>("path", description: "Path to input .glb"),
     Argument<String>("outputPath", description: ".scn output path")
-) { templatePath, templateParentNode, embedExternalImages, path, outputPath in
-    print("embedExternalImages", embedExternalImages)
+) { templatePath, templateParentNode, embedExternalImages, extractEmbeddedImages, path, outputPath in
+    print("embedExternalImages:", embedExternalImages)
+    print("extractEmbeddedImages:", embedExternalImages)
 //    let exportDelegate = ExportDelegate()
     
     var scene: SCNScene
     var templateScene = SCNScene()
     var parentNode: SCNNode
     do {
-        let sceneSource = try GLTFSceneSource(path: path, embedExternalImages: embedExternalImages)
+        let sceneSource = try GLTFSceneSource(path: path, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages)
         scene = try sceneSource.scene()
         
         if templatePath != "" {

--- a/gltf2scn/main.swift
+++ b/gltf2scn/main.swift
@@ -30,11 +30,14 @@ command(
     print("extractEmbeddedImages:", embedExternalImages)
 //    let exportDelegate = ExportDelegate()
     
+    let outputDirectoryPath = URL(fileURLWithPath: outputPath).deletingLastPathComponent().path
+    print("outputDirectoryPath is '\(outputDirectoryPath)'")
+    
     var scene: SCNScene
     var templateScene = SCNScene()
     var parentNode: SCNNode
     do {
-        let sceneSource = try GLTFSceneSource(path: path, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages)
+        let sceneSource = try GLTFSceneSource(path: path, embedExternalImages: embedExternalImages, extractEmbeddedImages: extractEmbeddedImages, outputDirectoryPath: outputDirectoryPath)
         scene = try sceneSource.scene()
         
         if templatePath != "" {


### PR DESCRIPTION
The new `--extract-embedded-images` flag can be used to **extract images embedded in a `.glb` file in their original file format.** We'll save the images in the output folder (i.e. root directory of `outputPath`).

Example command line usage:

```
mkdir ios
gltf2scn input.glb ios/scene.scn --extract-embedded-images
```

That command produces output like this in Finder:
<img width="680" alt="screen shot 2018-12-10 at 5 43 05 pm" src="https://user-images.githubusercontent.com/191304/49766387-20811780-fca3-11e8-8b54-7a64e46a30bf.png">